### PR TITLE
Added '[' to safe password characters

### DIFF
--- a/chpass.py
+++ b/chpass.py
@@ -44,7 +44,7 @@ def generate_password():
 
 
 def encode_password(password):
-    return quote(password, safe='')
+    return quote(password, safe='[')
 
 
 def login(username, password):


### PR DESCRIPTION
If you have the '[' character in your password, the encode_password function expands it - and
the login attempt will fail. If, however, it is marked as being safe, it is not encoded - and the
login attempt will succeed.